### PR TITLE
Improve Docker daemon connection error message

### DIFF
--- a/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
+++ b/python/packages/autogen-ext/src/autogen_ext/code_executors/docker/_docker_code_executor.py
@@ -336,7 +336,14 @@ $functions"""
             ) from e
 
         # Start a container from the image, read to exec commands later
-        client = docker.from_env()
+        try:
+            client = docker.from_env()
+        except Exception as e:
+            if "FileNotFoundError" in str(e):
+                raise RuntimeError(
+                    "Failed to connect to Docker daemon. Please make sure Docker is installed and running on your system."
+                ) from e
+            raise e
 
         # Check if the image exists
         try:


### PR DESCRIPTION
When Docker daemon is not running, the current error message is cryptic and not helpful:

```
Error while fetching server API version: ("Connection aborted.", FileNotFoundError(2, "No such file or directory"))
```

This PR improves the error message to be more user-friendly and actionable:

```
RuntimeError: Failed to connect to Docker daemon. Please make sure Docker is installed and running on your system.
```

The change wraps the Docker client initialization in a try-catch block and specifically looks for the FileNotFoundError case, which occurs when the Docker daemon is not running or the socket file is not found.